### PR TITLE
Update message instead of resend

### DIFF
--- a/rainwavebot.py
+++ b/rainwavebot.py
@@ -66,8 +66,8 @@ async def postCurrentlyListening(ctx = None, stopping=False):
             print(f"{current.playing} // {current.playing.id}", end ="")
         else:
             print('.', end ="")
-    except:
-        print("Not Syncing")
+    except Exception as returnedException:
+        print(f"postCurrentlyListening error: {returnedException}")
 
 def nowPlayingEmbed(metaData, stopping=False):
     class formatedEmbed:


### PR DESCRIPTION
@adamdiel Take a look!

This PR prevents the creation of a new message for every song, by editing the previous embed: 356ffc3493286cf994b1c0b7bef88e0c7b94dabb 

It also reworks the stop function to be a bit less redundant and to give more user feedback: ea88c5348e12c91ac4d5dbb0226fc8f795d398c1 7aaebbf73bc8a0a15624445ac75737eeca6d9d49 

Finally it changes `updatePlaying()` to `cancel` instead of `stop`. d464b9a279d744667c458a8922948357df4b1ccf