### PR TITLE
Restart sync/set max time

### DIFF
--- a/rainwavebot.py
+++ b/rainwavebot.py
@@ -48,7 +48,7 @@ def getChannelList():
 
 def checkSyncThreadIsAlive():
     try:
-        threadIsAlive = current.selectedStream._sync_thread.is_alive()
+        current.selectedStream._sync_thread.is_alive()
     except Exception as returnedException:
         #print(f"checkSyncThreadIsAlive error: {returnedException}") #NOTE Not required here, but I want to keep it noted as an example.
         #traceback.print_exc() #NOTE Not required here, but I want to keep it noted as an example.


### PR DESCRIPTION
Start sync removed from `play` command, moved to `postCurrentlyListening` via new function `checkSyncThreadIsAlive()`/  This checks the thread every refresh in case it ended for some reason.

`generateProgressBar()` now checks to make sure the song has not played longer than the maximum value of `.length` and replaces it with the max value if violated.  Also reduces `.seconds.` variable time conversion by one instance. 