### PR TITLE
VERSION_NUMBER bumped to "v1.0.1" discord.py bumped to 2.5.2

### DIFF
--- a/app/rainwavebot.py
+++ b/app/rainwavebot.py
@@ -19,7 +19,7 @@ from rainwaveclient import RainwaveClient #NOTE Command to upgrade the rainwavec
 import load_config.load_config
 
 #Global Constants
-VERSION_NUMBER = "v1.0.0"
+VERSION_NUMBER = "v1.0.1"
 MINIMUM_REFRESH_DELAY = 6
 PROJECT_HOME_PAGE = "https://github.com/clockwinder/RainwaveDiscordBot"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 #The first three were found using `pipreqs`, is that a good choice?  It did miss PyNaCl.
 aiocron==1.8 #Required for discord.py
-discord.py==2.4.0
+discord.py==2.5.2 #Bumped from 2.4.0
 python_rainwave_client==2024.2
 PyNaCl==1.5.0 #I got this by using `pip show pynacl`. If I hadn't known what would I do?
 PyYAML==6.0.2 #Allows reading Yamls


### PR DESCRIPTION
Resolves unknown library error preventing bot from connecting to voice:
```
File "/usr/local/lib/python3.12/site-packages/discord/ext/commands/core.py", line 244, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: ClientException: Not connected to voice.
```